### PR TITLE
Add configurable ellipsoid

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Parameters:
       µs on my computer
 - `ellipsoid` (`Ellipsoid`, optional): ellipsoid defined by its semi-major `a`
    and semi-minor `b` axes.
-   Default is WGS84 `Ellipsoid(a=6378137.0, b=6356752.3142451793)`.
+   Default: WGS84 ellipsoid.
 
 
 [bounding_sphere]: https://en.wikipedia.org/wiki/Bounding_sphere

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Parameters:
     - `None`: Runs both the naive and the ritter methods, then returns the
       smaller of the two. Since this runs both algorithms, it takes around 500
       µs on my computer
+- `ellipsoid` (`Ellipsoid`, optional): ellipsoid defined by its semi-major `a`
+   and semi-minor `b` axes.
+   Default is WGS84 `Ellipsoid(a=6378137.0, b=6356752.3142451793)`.
 
 
 [bounding_sphere]: https://en.wikipedia.org/wiki/Bounding_sphere

--- a/quantized_mesh_encoder/__init__.py
+++ b/quantized_mesh_encoder/__init__.py
@@ -4,6 +4,5 @@ __author__ = """Kyle Barron"""
 __email__ = 'kylebarron2@gmail.com'
 __version__ = '0.3.1'
 
-from .encode import encode
-
 from .ellipsoid import Ellipsoid
+from .encode import encode

--- a/quantized_mesh_encoder/__init__.py
+++ b/quantized_mesh_encoder/__init__.py
@@ -5,3 +5,5 @@ __email__ = 'kylebarron2@gmail.com'
 __version__ = '0.3.1'
 
 from .encode import encode
+
+from .ellipsoid import Ellipsoid

--- a/quantized_mesh_encoder/constants.py
+++ b/quantized_mesh_encoder/constants.py
@@ -1,20 +1,6 @@
 import numpy as np
 
-# From https://github.com/loicgasser/quantized-mesh-tile/blob/master/quantized_mesh_tile/llh_ecef.py
-# Constants taken from http://cesiumjs.org/2013/04/25/Horizon-culling/
-RADIUS_X = 6378137.0
-RADIUS_Y = 6378137.0
-RADIUS_Z = 6356752.3142451793
-
-# Stolen from https://github.com/bistromath/gr-air-modes/blob/master/python/mlat.py
-# WGS84 reference ellipsoid constants
-# http://en.wikipedia.org/wiki/Geodetic_datum#Conversion_calculations
-# http://en.wikipedia.org/wiki/File%3aECEF.png
-WGS84_A = RADIUS_X  # Semi-major axis
-WGS84_B = RADIUS_Z  # Semi-minor axis
-WGS84_E2 = 0.0066943799901975848  # First eccentricity squared
-WGS84_A2 = WGS84_A ** 2  # To speed things up a bit
-WGS84_B2 = WGS84_B ** 2
+WGS84 = { "a": 6378137.0, "b": 6356752.3142451793 }
 
 NP_STRUCT_TYPES = {
     np.float32: '<f',

--- a/quantized_mesh_encoder/constants.py
+++ b/quantized_mesh_encoder/constants.py
@@ -1,4 +1,5 @@
 import numpy as np
+
 from .ellipsoid import Ellipsoid
 
 WGS84 = Ellipsoid(a=6378137.0, b=6356752.3142451793)

--- a/quantized_mesh_encoder/constants.py
+++ b/quantized_mesh_encoder/constants.py
@@ -1,6 +1,7 @@
 import numpy as np
+from .ellipsoid import Ellipsoid
 
-WGS84 = { "a": 6378137.0, "b": 6356752.3142451793 }
+WGS84 = Ellipsoid(a=6378137.0, b=6356752.3142451793)
 
 NP_STRUCT_TYPES = {
     np.float32: '<f',

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -19,7 +19,6 @@ def to_ecef(positions, ellipsoid = WGS84):
         - ellisoid: a dict that defines an ellipsoid with with "a" and "b" values. Defaults to WGS84
     from latitude-longitude-height to ecef
     """
-    ellipsoid_e2 = 1 - (ellipsoid["b"]**2 / ellipsoid["a"]**2)
     lon = positions[:, 0]
     lat = positions[:, 1]
     alt = positions[:, 2]
@@ -27,12 +26,12 @@ def to_ecef(positions, ellipsoid = WGS84):
     lat *= np.pi / 180
     lon *= np.pi / 180
 
-    n = lambda arr: ellipsoid["a"] / np.sqrt(1 - ellipsoid_e2 * (np.square(np.sin(arr))))
+    n = lambda arr: ellipsoid.a / np.sqrt(1 - ellipsoid.e2* (np.square(np.sin(arr))))
     nlat = n(lat)
 
     x = (nlat + alt) * np.cos(lat) * np.cos(lon)
     y = (nlat + alt) * np.cos(lat) * np.sin(lon)
-    z = (nlat * (1 - ellipsoid_e2) + alt) * np.sin(lat)
+    z = (nlat * (1 - ellipsoid.e2) + alt) * np.sin(lat)
 
     # Do I need geoid correction?
     # https://github.com/bistromath/gr-air-modes/blob/9e2515a56609658f168f0c833a14ca4d2332713e/python/mlat.py#L88-L92

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -17,13 +17,13 @@ def to_ecef(positions, ellipsoid=WGS84):
 
     Args:
         - positions: expected to be an ndarray with shape (-1, 3)
-        from latitude-longitude-height to ecef
+          from latitude-longitude-height to ecef
         - ellipsoid: (`Ellipsoid`): ellipsoid defined by its semi-major `a`
           and semi-minor `b` axes. Default: WGS84 ellipsoid.
     """
     assert isinstance(
         ellipsoid,
-        Ellipsoid), 'ellipsoid must be an instance of the Ellipsoid class'
+        Ellipsoid), ('ellipsoid must be an instance of the Ellipsoid class')
 
     lon = positions[:, 0]
     lat = positions[:, 1]

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -1,9 +1,9 @@
 import numpy as np
 
-from .constants import WGS84_A, WGS84_E2
+from .constants import WGS84
 
 
-def to_ecef(positions):
+def to_ecef(positions, ellipsoid = WGS84):
     """Convert positions to earth-centered, earth-fixed coordinates
 
     Ported from
@@ -16,9 +16,10 @@ def to_ecef(positions):
 
     Args:
         - positions: expected to be an ndarray with shape (-1, 3)
-    from latitude-longitude-height to
+        - ellisoid: a dict that defines an ellipsoid with with "a" and "b" values. Defaults to WGS84
+    from latitude-longitude-height to ecef
     """
-
+    ellipsoid_e2 = 1 - (ellipsoid["b"]**2 / ellipsoid["a"]**2)
     lon = positions[:, 0]
     lat = positions[:, 1]
     alt = positions[:, 2]
@@ -26,12 +27,12 @@ def to_ecef(positions):
     lat *= np.pi / 180
     lon *= np.pi / 180
 
-    n = lambda arr: WGS84_A / np.sqrt(1 - WGS84_E2 * (np.square(np.sin(arr))))
+    n = lambda arr: ellipsoid["a"] / np.sqrt(1 - ellipsoid_e2 * (np.square(np.sin(arr))))
     nlat = n(lat)
 
     x = (nlat + alt) * np.cos(lat) * np.cos(lon)
     y = (nlat + alt) * np.cos(lat) * np.sin(lon)
-    z = (nlat * (1 - WGS84_E2) + alt) * np.sin(lat)
+    z = (nlat * (1 - ellipsoid_e2) + alt) * np.sin(lat)
 
     # Do I need geoid correction?
     # https://github.com/bistromath/gr-air-modes/blob/9e2515a56609658f168f0c833a14ca4d2332713e/python/mlat.py#L88-L92

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -3,7 +3,7 @@ import numpy as np
 from .constants import WGS84
 
 
-def to_ecef(positions, ellipsoid = WGS84):
+def to_ecef(positions, ellipsoid=WGS84):
     """Convert positions to earth-centered, earth-fixed coordinates
 
     Ported from
@@ -26,7 +26,8 @@ def to_ecef(positions, ellipsoid = WGS84):
     lat *= np.pi / 180
     lon *= np.pi / 180
 
-    n = lambda arr: ellipsoid.a / np.sqrt(1 - ellipsoid.e2* (np.square(np.sin(arr))))
+    n = lambda arr: ellipsoid.a / np.sqrt(
+        1 - ellipsoid.e2 * (np.square(np.sin(arr))))
     nlat = n(lat)
 
     x = (nlat + alt) * np.cos(lat) * np.cos(lon)

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -16,9 +16,14 @@ def to_ecef(positions, ellipsoid=WGS84):
 
     Args:
         - positions: expected to be an ndarray with shape (-1, 3)
-        - ellisoid: a dict that defines an ellipsoid with with "a" and "b" values. Defaults to WGS84
-    from latitude-longitude-height to ecef
+        from latitude-longitude-height to ecef
+        - ellipsoid: (`Ellipsoid`): ellipsoid defined by its semi-major `a`
+          and semi-minor `b` axes. Default: WGS84 ellipsoid.
     """
+    assert isinstance(
+        ellipsoid,
+        Ellipsoid), 'ellipsoid must be an instance of the Ellipsoid class'
+
     lon = positions[:, 0]
     lat = positions[:, 1]
     alt = positions[:, 2]

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 from .constants import WGS84
+from .ellipsoid import Ellipsoid
 
 
 def to_ecef(positions, ellipsoid=WGS84):

--- a/quantized_mesh_encoder/ellipsoid.py
+++ b/quantized_mesh_encoder/ellipsoid.py
@@ -1,0 +1,12 @@
+
+from dataclasses import dataclass, field
+
+@dataclass
+class Ellipsoid:
+    a: float
+    b: float
+    e2: float = field(init=False)
+
+    def __post_init__(self):
+        self.e2 = 1 - (self.b**2 / self.a**2)
+

--- a/quantized_mesh_encoder/ellipsoid.py
+++ b/quantized_mesh_encoder/ellipsoid.py
@@ -1,5 +1,5 @@
-
 from dataclasses import dataclass, field
+
 
 @dataclass
 class Ellipsoid:
@@ -8,5 +8,4 @@ class Ellipsoid:
     e2: float = field(init=False)
 
     def __post_init__(self):
-        self.e2 = 1 - (self.b**2 / self.a**2)
-
+        self.e2 = 1 - (self.b ** 2 / self.a ** 2)

--- a/quantized_mesh_encoder/encode.py
+++ b/quantized_mesh_encoder/encode.py
@@ -68,7 +68,7 @@ def encode(
 
     assert isinstance(
         ellipsoid,
-        Ellipsoid), 'ellipsoid must be an instance of the Ellipsoid class'
+        Ellipsoid), ('ellipsoid must be an instance of the Ellipsoid class')
 
     header = compute_header(positions, sphere_method, ellipsoid=ellipsoid)
     encode_header(f, header)

--- a/quantized_mesh_encoder/encode.py
+++ b/quantized_mesh_encoder/encode.py
@@ -3,14 +3,14 @@ from struct import pack
 import numpy as np
 
 from .bounding_sphere import bounding_sphere
-from .constants import HEADER, NP_STRUCT_TYPES, VERTEX_DATA
+from .constants import HEADER, NP_STRUCT_TYPES, VERTEX_DATA, WGS84
 from .ecef import to_ecef
 from .occlusion import occlusion_point
 from .util import zig_zag_encode
 from .util_cy import encode_indices
 
 
-def encode(f, positions, indices, bounds=None, sphere_method=None):
+def encode(f, positions, indices, bounds=None, sphere_method=None, ellipsoid=WGS84):
     """Create bounding sphere from positions
 
     Args:
@@ -51,13 +51,14 @@ def encode(f, positions, indices, bounds=None, sphere_method=None):
           - None: Runs both the naive and the ritter methods, then returns the
             smaller of the two. Since this runs both algorithms, it takes around
             500 µs on my computer
+        - ellisoid: a dict that defines an ellipsoid with with "a" and "b" values. Defaults to WGS84
     """
 
     # Convert to ndarray
     positions = positions.reshape(-1, 3).astype(np.float32)
     indices = indices.reshape(-1, 3).astype(np.uint32)
 
-    header = compute_header(positions, sphere_method)
+    header = compute_header(positions, sphere_method, ellipsoid)
     encode_header(f, header)
 
     # Linear interpolation to range u, v, h from 0-32767
@@ -71,9 +72,9 @@ def encode(f, positions, indices, bounds=None, sphere_method=None):
     write_edge_indices(f, positions, n_vertices)
 
 
-def compute_header(positions, sphere_method):
+def compute_header(positions, sphere_method, ellipsoid = WGS84):
     header = {}
-    cartesian_positions = to_ecef(positions)
+    cartesian_positions = to_ecef(positions, ellipsoid)
 
     ecef_min_x = cartesian_positions[:, 0].min()
     ecef_min_y = cartesian_positions[:, 1].min()
@@ -95,7 +96,7 @@ def compute_header(positions, sphere_method):
     header['boundingSphereCenterZ'] = center[2]
     header['boundingSphereRadius'] = radius
 
-    occl_pt = occlusion_point(cartesian_positions, center)
+    occl_pt = occlusion_point(cartesian_positions, center, ellipsoid)
     header['horizonOcclusionPointX'] = occl_pt[0]
     header['horizonOcclusionPointY'] = occl_pt[1]
     header['horizonOcclusionPointZ'] = occl_pt[2]

--- a/quantized_mesh_encoder/encode.py
+++ b/quantized_mesh_encoder/encode.py
@@ -59,7 +59,7 @@ def encode(
             smaller of the two. Since this runs both algorithms, it takes around
             500 µs on my computer
         - ellipsoid: (`Ellipsoid`): ellipsoid defined by its semi-major `a`
-          and semi-minor `b` axes.
+          and semi-minor `b` axes. Default: WGS84 ellipsoid.
     """
 
     # Convert to ndarray
@@ -86,7 +86,7 @@ def encode(
 
 def compute_header(positions, sphere_method, ellipsoid=WGS84):
     header = {}
-    cartesian_positions = to_ecef(positions, ellipsoid)
+    cartesian_positions = to_ecef(positions, ellipsoid=ellipsoid)
 
     ecef_min_x = cartesian_positions[:, 0].min()
     ecef_min_y = cartesian_positions[:, 1].min()

--- a/quantized_mesh_encoder/encode.py
+++ b/quantized_mesh_encoder/encode.py
@@ -3,15 +3,21 @@ from struct import pack
 import numpy as np
 
 from .bounding_sphere import bounding_sphere
-from .ellipsoid import Ellipsoid
 from .constants import HEADER, NP_STRUCT_TYPES, VERTEX_DATA, WGS84
 from .ecef import to_ecef
+from .ellipsoid import Ellipsoid
 from .occlusion import occlusion_point
 from .util import zig_zag_encode
 from .util_cy import encode_indices
 
 
-def encode(f, positions, indices, bounds=None, sphere_method=None, ellipsoid=WGS84):
+def encode(
+        f,
+        positions,
+        indices,
+        bounds=None,
+        sphere_method=None,
+        ellipsoid=WGS84):
     """Create bounding sphere from positions
 
     Args:
@@ -60,7 +66,9 @@ def encode(f, positions, indices, bounds=None, sphere_method=None, ellipsoid=WGS
     positions = positions.reshape(-1, 3).astype(np.float32)
     indices = indices.reshape(-1, 3).astype(np.uint32)
 
-    assert isinstance(ellipsoid, Ellipsoid), 'ellipsoid must be an instance of the Ellipsoid class'
+    assert isinstance(
+        ellipsoid,
+        Ellipsoid), 'ellipsoid must be an instance of the Ellipsoid class'
 
     header = compute_header(positions, sphere_method, ellipsoid=ellipsoid)
     encode_header(f, header)
@@ -76,7 +84,7 @@ def encode(f, positions, indices, bounds=None, sphere_method=None, ellipsoid=WGS
     write_edge_indices(f, positions, n_vertices)
 
 
-def compute_header(positions, sphere_method, ellipsoid = WGS84):
+def compute_header(positions, sphere_method, ellipsoid=WGS84):
     header = {}
     cartesian_positions = to_ecef(positions, ellipsoid)
 

--- a/quantized_mesh_encoder/occlusion.py
+++ b/quantized_mesh_encoder/occlusion.py
@@ -31,15 +31,15 @@ def compute_magnitude(positions, bounding_center):
 
 # https://cesiumjs.org/2013/05/09/Computing-the-horizon-occlusion-point/
 def occlusion_point(positions, bounding_center, ellipsoid = WGS84):
-    ellipsoid = np.array([ellipsoid["a"], ellipsoid["a"], ellipsoid["b"]])
+    cartesian_ellipsoid = np.array([ellipsoid.a, ellipsoid.a, ellipsoid.b])
     # Scale positions relative to ellipsoid
-    positions /= ellipsoid
+    positions /= cartesian_ellipsoid
 
     # Scale center relative to ellipsoid
-    bounding_center /= ellipsoid
+    bounding_center /= cartesian_ellipsoid
 
     # Find magnitudes necessary for each position to not be visible
     magnitudes = compute_magnitude(positions, bounding_center)
 
     # Multiply by maximum magnitude and rescale to ellipsoid surface
-    return bounding_center * magnitudes.max() * ellipsoid
+    return bounding_center * magnitudes.max() * cartesian_ellipsoid

--- a/quantized_mesh_encoder/occlusion.py
+++ b/quantized_mesh_encoder/occlusion.py
@@ -30,7 +30,7 @@ def compute_magnitude(positions, bounding_center):
 
 
 # https://cesiumjs.org/2013/05/09/Computing-the-horizon-occlusion-point/
-def occlusion_point(positions, bounding_center, ellipsoid = WGS84):
+def occlusion_point(positions, bounding_center, ellipsoid=WGS84):
     cartesian_ellipsoid = np.array([ellipsoid.a, ellipsoid.a, ellipsoid.b])
     # Scale positions relative to ellipsoid
     positions /= cartesian_ellipsoid

--- a/quantized_mesh_encoder/occlusion.py
+++ b/quantized_mesh_encoder/occlusion.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from .constants import RADIUS_X, RADIUS_Y, RADIUS_Z
+from .constants import WGS84
 
 
 def squared_norm(positions):
@@ -30,8 +30,8 @@ def compute_magnitude(positions, bounding_center):
 
 
 # https://cesiumjs.org/2013/05/09/Computing-the-horizon-occlusion-point/
-def occlusion_point(positions, bounding_center):
-    ellipsoid = np.array([RADIUS_X, RADIUS_Y, RADIUS_Z])
+def occlusion_point(positions, bounding_center, ellipsoid = WGS84):
+    ellipsoid = np.array([ellipsoid["a"], ellipsoid["a"], ellipsoid["b"]])
     # Scale positions relative to ellipsoid
     positions /= ellipsoid
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ with open("README.md") as f:
     readme = f.read()
 
 # Runtime requirements.
-inst_reqs = ["numpy"]
+inst_reqs = ["numpy", "dataclasses;python_version<'3.7'"]
 
 extra_reqs = {
     "test": ["pytest", "pytest-benchmark", "imageio", "quantized-mesh-tile"], }


### PR DESCRIPTION
This adds the option for a user to supply an ellipsoid other than WGS84 to encode quantized-mesh tiles. Useful for generating terrain tiles for non-earth objects. 