### PR TITLE
Vertex Normals support

### DIFF
--- a/quantized_mesh_encoder/constants.py
+++ b/quantized_mesh_encoder/constants.py
@@ -1,3 +1,5 @@
+from enum import IntEnum
+
 import numpy as np
 
 from .ellipsoid import Ellipsoid
@@ -55,6 +57,10 @@ EDGE_INDICES32 = {
     'northVertexCount': '<I',
     'northIndices': '<I'}
 
-EXTENSION_HEADER = {
-    'extensionId': '<B',
-    'extensionLength': '<I'}
+EXTENSION_HEADER = {'extensionId': '<B', 'extensionLength': '<I'}
+
+
+class QuantizedMeshExtensions(IntEnum):
+    VERTEX_NORMALS = 1
+    WATER_MASK = 2
+    METADATA = 4

--- a/quantized_mesh_encoder/constants.py
+++ b/quantized_mesh_encoder/constants.py
@@ -1,5 +1,3 @@
-from enum import IntEnum
-
 import numpy as np
 
 from .ellipsoid import Ellipsoid
@@ -58,9 +56,3 @@ EDGE_INDICES32 = {
     'northIndices': '<I'}
 
 EXTENSION_HEADER = {'extensionId': '<B', 'extensionLength': '<I'}
-
-
-class QuantizedMeshExtensions(IntEnum):
-    VERTEX_NORMALS = 1
-    WATER_MASK = 2
-    METADATA = 4

--- a/quantized_mesh_encoder/constants.py
+++ b/quantized_mesh_encoder/constants.py
@@ -54,3 +54,7 @@ EDGE_INDICES32 = {
     'eastIndices': '<I',
     'northVertexCount': '<I',
     'northIndices': '<I'}
+
+EXTENSION_HEADER = {
+    'extensionId': '<B',
+    'extensionLength': '<I'}

--- a/quantized_mesh_encoder/ecef.py
+++ b/quantized_mesh_encoder/ecef.py
@@ -25,12 +25,9 @@ def to_ecef(positions, ellipsoid=WGS84):
         ellipsoid,
         Ellipsoid), ('ellipsoid must be an instance of the Ellipsoid class')
 
-    lon = positions[:, 0]
-    lat = positions[:, 1]
+    lon = positions[:, 0] * np.pi / 180
+    lat = positions[:, 1] * np.pi / 180
     alt = positions[:, 2]
-
-    lat *= np.pi / 180
-    lon *= np.pi / 180
 
     n = lambda arr: ellipsoid.a / np.sqrt(
         1 - ellipsoid.e2 * (np.square(np.sin(arr))))

--- a/quantized_mesh_encoder/encode.py
+++ b/quantized_mesh_encoder/encode.py
@@ -100,7 +100,7 @@ def encode(
     write_edge_indices(f, positions, n_vertices)
 
     for ext in extensions:
-        if isinstance(ext, VertexNormalsExtension):
+        if isinstance(ext, ExtensionBase):
             f.write(ext.encode())
 
 

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -30,9 +30,9 @@ class ExtensionBase(metaclass=abc.ABCMeta):
 
 @dataclass
 class VertexNormalsExtension(ExtensionBase):
+    id: ExtensionId = field(init=False, default=ExtensionId.VERTEX_NORMALS)
     indices: np.ndarray
     positions: np.ndarray
-    id: ExtensionId = ExtensionId.VERTEX_NORMALS
     ellipsoid: Ellipsoid = WGS84
 
     def encode(self) -> bytes:

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -1,13 +1,46 @@
-from dataclasses import dataclass
+import abc
+from dataclasses import dataclass, field
+from enum import IntEnum
+from struct import pack
 
-from .constants import QuantizedMeshExtensions
+import numpy as np
+
+from .constants import EXTENSION_HEADER, WGS84
+from .ellipsoid import Ellipsoid
+from .normals import compute_vertex_normals, oct_encode
+
+
+class ExtensionId(IntEnum):
+    VERTEX_NORMALS = 1
+    WATER_MASK = 2
+    METADATA = 4
 
 
 @dataclass
-class ExtensionBase:
-    extension_id: int
+class ExtensionBase(metaclass=abc.ABCMeta):
+    id: ExtensionId = field(init=False)
+
+    @property
+    @abc.abstractmethod
+    def encode(self) -> bytes:
+        """"Return the encoded extension data"""
+        ...
 
 
 @dataclass
 class VertexNormalsExtension(ExtensionBase):
-    extension_id: str = QuantizedMeshExtensions.VERTEX_NORMALS
+    id: ExtensionId = field(init=False, default=ExtensionId.VERTEX_NORMALS)
+    indices: np.ndarray
+    positions: np.ndarray
+    ellipsoid: Ellipsoid = WGS84
+
+    def encode(self) -> bytes:
+        normals = compute_vertex_normals(self.positions, self.indices)
+        encoded = oct_encode(normals).tobytes('C')
+
+        buf = b''
+        buf += pack(EXTENSION_HEADER['extensionId'], ExtensionId.VERTEX_NORMALS)
+        buf += pack(EXTENSION_HEADER['extensionLength'], len(encoded))
+        buf += encoded
+
+        return buf

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -19,7 +19,7 @@ class ExtensionId(IntEnum):
 
 @dataclass
 class ExtensionBase(metaclass=abc.ABCMeta):
-    id: ExtensionId = field(init=False)
+    id: ExtensionId
 
     @property
     @abc.abstractmethod
@@ -30,9 +30,9 @@ class ExtensionBase(metaclass=abc.ABCMeta):
 
 @dataclass
 class VertexNormalsExtension(ExtensionBase):
-    id: ExtensionId = field(init=False, default=ExtensionId.VERTEX_NORMALS)
     indices: np.ndarray
     positions: np.ndarray
+    id: ExtensionId = ExtensionId.VERTEX_NORMALS
     ellipsoid: Ellipsoid = WGS84
 
     def encode(self) -> bytes:

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -1,0 +1,13 @@
+from dataclasses import dataclass
+
+from .constants import QuantizedMeshExtensions
+
+
+@dataclass
+class ExtensionBase:
+    extension_id: int
+
+
+@dataclass
+class VertexNormalsExtension(ExtensionBase):
+    extension_id: str = QuantizedMeshExtensions.VERTEX_NORMALS

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -6,6 +6,7 @@ from struct import pack
 import numpy as np
 
 from .constants import EXTENSION_HEADER, WGS84
+from .ecef import to_ecef
 from .ellipsoid import Ellipsoid
 from .normals import compute_vertex_normals, oct_encode
 
@@ -35,7 +36,9 @@ class VertexNormalsExtension(ExtensionBase):
     ellipsoid: Ellipsoid = WGS84
 
     def encode(self) -> bytes:
-        normals = compute_vertex_normals(self.positions, self.indices)
+        positions = self.positions.reshape(-1, 3)
+        cartesian_positions = to_ecef(positions)
+        normals = compute_vertex_normals(cartesian_positions, self.indices)
         encoded = oct_encode(normals).tobytes('C')
 
         buf = b''

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -19,7 +19,7 @@ class ExtensionId(IntEnum):
 
 @dataclass
 class ExtensionBase(metaclass=abc.ABCMeta):
-    id: ExtensionId
+    id: ExtensionId = field(init=False)
 
     @property
     @abc.abstractmethod

--- a/quantized_mesh_encoder/extensions.py
+++ b/quantized_mesh_encoder/extensions.py
@@ -37,7 +37,7 @@ class VertexNormalsExtension(ExtensionBase):
 
     def encode(self) -> bytes:
         positions = self.positions.reshape(-1, 3)
-        cartesian_positions = to_ecef(positions)
+        cartesian_positions = to_ecef(positions, self.ellipsoid)
         normals = compute_vertex_normals(cartesian_positions, self.indices)
         encoded = oct_encode(normals).tobytes('C')
 

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from .util_cy import add_vertex_normals
+
 
 def compute_vertex_normals(positions, indices):
     # Make sure indices and positions are both arrays of shape (-1, 3)
@@ -32,11 +34,8 @@ def compute_vertex_normals(positions, indices):
     # Sum up each vertex normal
     # According to the implementation this is ported from, since you weight the
     # face normals by the area, you can just sum up the vectors.
-    # TODO move to cython
     vertex_normals = np.zeros(positions.shape, dtype=np.float32)
-    for triangle, face_norm in zip(indices, weighted_face_normals):
-        for pos in triangle:
-            vertex_normals[pos] += face_norm
+    add_vertex_normals(indices, weighted_face_normals, vertex_normals)
 
     # Normalize vertex normals by dividing by each vector's length
     normalized_vertex_normals = vertex_normals / np.linalg.norm(

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -5,7 +5,7 @@ from .util_cy import add_vertex_normals
 
 def compute_vertex_normals(positions, indices):
     # Make sure indices and positions are both arrays of shape (-1, 3)
-    positions = positions.reshape(-1, 3)
+    positions = positions.reshape(-1, 3).astype('float64')
     indices = indices.reshape(-1, 3)
 
     # Perform coordinate lookup in positions using indices
@@ -34,7 +34,7 @@ def compute_vertex_normals(positions, indices):
     # Sum up each vertex normal
     # According to the implementation this is ported from, since you weight the
     # face normals by the area, you can just sum up the vectors.
-    vertex_normals = np.zeros(positions.shape, dtype=np.float32)
+    vertex_normals = np.zeros(positions.shape, dtype=np.float64)
     add_vertex_normals(indices, weighted_face_normals, vertex_normals)
 
     # Normalize vertex normals by dividing by each vector's length
@@ -42,6 +42,10 @@ def compute_vertex_normals(positions, indices):
         vertex_normals, axis=1)[:, np.newaxis]
 
     return normalized_vertex_normals
+
+
+def signNotZero(v):
+    return -1.0 if v < 0.0 else 1.0
 
 
 def oct_encode(vec):
@@ -56,13 +60,12 @@ def oct_encode(vec):
     l1_norm = np.linalg.norm(vec, ord=1, axis=1)
     result = vec[:, 0:2] / l1_norm[:, np.newaxis]
 
-    # TODO: Is 3rd position ever negative?
-    # Might depend on triangle winding order...
-    # if vec[2] < 0.0:
-    #     x = res[0]
-    #     y = res[1]
-    #     res[0] = (1.0 - abs(y)) * signNotZero(x)
-    #     res[1] = (1.0 - abs(x)) * signNotZero(y)
+    for i, res in enumerate(result):
+        if vec[i, 2] < 0.0:
+            x = res[0]
+            y = res[1]
+            res[0] = (1.0 - abs(y)) * signNotZero(x)
+            res[1] = (1.0 - abs(x)) * signNotZero(y)
 
     # Converts a scalar value in the range [-1.0, 1.0] to a 8-bit 2's complement
     # number.

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -46,8 +46,7 @@ def compute_vertex_normals(positions, indices):
 
 def sign_not_zero(arr):
     """A variation of np.sign that coerces 0 to 1"""
-    signed = np.sign(arr)
-    return np.where(signed == 0, 1, signed)
+    return np.where(arr < 0.0, -1, 1)
 
 
 def oct_encode(vec):

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -12,7 +12,7 @@ def compute_vertex_normals(positions, indices):
     # positions and indices are both arrays of shape (-1, 3)
     # `coords` is then an array of shape (-1, 3, 3) where each block of (i, 3,
     # 3) represents all the coordinates of a single triangle
-    tri_coords = positions[indices]
+    tri_coords = positions[indices].astype('float32')
 
     # a, b, and c represent a single vertex for every triangle
     a = tri_coords[:, 0, :]

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -44,8 +44,10 @@ def compute_vertex_normals(positions, indices):
     return normalized_vertex_normals
 
 
-def signNotZero(v):
-    return -1.0 if v < 0.0 else 1.0
+def sign_not_zero(arr):
+    """A variation of np.sign that coerces 0 to 1"""
+    signed = np.sign(arr)
+    return np.where(signed == 0, 1, signed)
 
 
 def oct_encode(vec):
@@ -60,12 +62,13 @@ def oct_encode(vec):
     l1_norm = np.linalg.norm(vec, ord=1, axis=1)
     result = vec[:, 0:2] / l1_norm[:, np.newaxis]
 
-    for i, res in enumerate(result):
-        if vec[i, 2] < 0.0:
-            x = res[0]
-            y = res[1]
-            res[0] = (1.0 - abs(y)) * signNotZero(x)
-            res[1] = (1.0 - abs(x)) * signNotZero(y)
+    negative = vec[:, 2] < 0.0
+    x = np.copy(result[:, 0])
+    y = np.copy(result[:, 1])
+    result[:, 0] = np.where(
+        negative, (1 - np.abs(y)) * sign_not_zero(x), result[:, 0])
+    result[:, 1] = np.where(
+        negative, (1 - np.abs(x)) * sign_not_zero(y), result[:, 1])
 
     # Converts a scalar value in the range [-1.0, 1.0] to a 8-bit 2's complement
     # number.

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -1,0 +1,38 @@
+import numpy as np
+
+indices = triangles
+def compute_normals(positions, indices):
+    # Make sure indices
+    indices = indices.reshape(-1, 3)
+
+    # Perform coordinate lookup in positions using indices
+    # `coords` is then an array of shape (-1, 3, 3) where each block of (i, 3,
+    # 3) represents all the coordinates of a single triangle
+    coords = positions[indices]
+
+    a = coords[:, 0, :]
+    b = coords[:, 1, :]
+    c = coords[:, 2, :]
+
+    normal = np.cross(b - a, c - a)
+
+    # How to aggregate triangles per vertex?
+    # I essentially need to do: For every vertex, what are the indices of
+    # `indices` that touch that vertex. This is basically a double for loop, or
+    # at least a single for loop that does
+    #     for i in range(indices.max()):
+    #        (indices == i).any(axis=1)
+    #
+    # That's obviously slow, and I'm not sure how to broadcast, because I'd need
+    # to broadcast arrays of two different sizes.
+    #
+    # https://stackoverflow.com/q/53631460
+    # https://stackoverflow.com/q/8251541
+
+    x = np.arange(indices.max())
+
+    # # Pseudo-code
+    # references = {}
+    # for row in indices.rows():
+    #     for value in row:
+    #         references[value].append(row_index)

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -58,6 +58,7 @@ def oct_encode(vec):
     result = vec[:, 0:2] / l1_norm[:, np.newaxis]
 
     # TODO: Is 3rd position ever negative?
+    # Might depend on triangle winding order...
     # if vec[2] < 0.0:
     #     x = res[0]
     #     y = res[1]

--- a/quantized_mesh_encoder/normals.py
+++ b/quantized_mesh_encoder/normals.py
@@ -12,7 +12,7 @@ def compute_vertex_normals(positions, indices):
     # positions and indices are both arrays of shape (-1, 3)
     # `coords` is then an array of shape (-1, 3, 3) where each block of (i, 3,
     # 3) represents all the coordinates of a single triangle
-    tri_coords = positions[indices].astype('float32')
+    tri_coords = positions[indices]
 
     # a, b, and c represent a single vertex for every triangle
     a = tri_coords[:, 0, :]
@@ -66,7 +66,7 @@ def oct_encode(vec):
 
     # Converts a scalar value in the range [-1.0, 1.0] to a 8-bit 2's complement
     # number.
-    oct_encoded = np.floor(
-        (np.clip(result, -1, 1) * .5 + .5) * 256).astype(np.uint8)
+    oct_encoded = np.floor((np.clip(result, -1, 1) * .5 + .5) * 256).astype(
+        np.uint8)
 
     return oct_encoded

--- a/quantized_mesh_encoder/util_cy.pyx
+++ b/quantized_mesh_encoder/util_cy.pyx
@@ -78,8 +78,8 @@ def ritter_second_pass(
 #         vertex_normals[pos] += face_norm
 def add_vertex_normals(
     np.ndarray[np.uint32_t, ndim=2] indices,
-    np.ndarray[np.float32_t, ndim=2] normals,
-    np.ndarray[np.float32_t, ndim=2] out):
+    np.ndarray[np.float64_t, ndim=2] normals,
+    np.ndarray[np.float64_t, ndim=2] out):
 
     cdef long long indices_length = indices.shape[0]
     cdef Py_ssize_t i, j, k

--- a/quantized_mesh_encoder/util_cy.pyx
+++ b/quantized_mesh_encoder/util_cy.pyx
@@ -1,6 +1,5 @@
 import numpy as np
 cimport numpy as np
-import math
 
 def encode_indices(indices):
     """High-water mark encoding
@@ -70,3 +69,24 @@ def ritter_second_pass(
         centerZ += (mult * dPz)
 
     return np.array([centerX, centerY, centerZ], dtype=np.float32), radius
+
+
+# Cython implementation of:
+# vertex_normals = np.zeros(positions.shape, dtype=np.float32)
+# for triangle, face_norm in zip(indices, weighted_face_normals):
+#     for pos in triangle:
+#         vertex_normals[pos] += face_norm
+def add_vertex_normals(
+    np.ndarray[np.uint32_t, ndim=2] indices,
+    np.ndarray[np.float32_t, ndim=2] normals,
+    np.ndarray[np.float32_t, ndim=2] out):
+
+    cdef long long indices_length = indices.shape[0]
+    cdef Py_ssize_t i, j, k
+    cdef long long vertex
+
+    for i in range(indices_length):
+        for j in range(3):
+            for k in range(3):
+                vertex = indices[i, j]
+                out[vertex, k] += normals[i, k]

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -53,15 +53,15 @@ def test_encode_header():
 
 
 def test_encode_decode():
+
     positions = np.array(
         [0, 0, 0, 1, 1, 1, 0, 1, 4, 2, 3, 4, 8, 9, 10, 12, 13, 14],
         dtype=np.float32)
     triangles = np.array([0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 5], dtype=np.uint32)
-
     cartesian_positions = to_ecef(positions.reshape(-1, 3))
 
     normals_ext = extensions.VertexNormalsExtension(
-        positions=positions, indices=triangles)
+        positions=cartesian_positions, indices=triangles)
 
     f = BytesIO()
     encode(f, positions, triangles, extensions=[normals_ext])
@@ -87,5 +87,7 @@ def test_encode_decode():
     assert tile.northI == [5]
 
     normals = compute_vertex_normals(cartesian_positions, triangles)
-    assert np.array_equal(
-        normals, np.array(tile.vLight)), 'VertexNormals incorrect'
+
+    # Can't test for exact equality with octencode/decode
+    assert np.allclose(
+        normals, tile.vLight, atol=0.01, rtol=0), 'VertexNormals incorrect'

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -61,7 +61,7 @@ def test_encode_decode():
     cartesian_positions = to_ecef(positions.reshape(-1, 3))
 
     normals_ext = extensions.VertexNormalsExtension(
-        positions=cartesian_positions, indices=triangles)
+        positions=positions, indices=triangles)
 
     f = BytesIO()
     encode(f, positions, triangles, extensions=[normals_ext])

--- a/test/test_encode.py
+++ b/test/test_encode.py
@@ -5,18 +5,18 @@ import numpy as np
 from quantized_mesh_tile import TerrainTile
 
 from quantized_mesh_encoder import extensions
+from quantized_mesh_encoder.constants import WGS84
 from quantized_mesh_encoder.ecef import to_ecef
 from quantized_mesh_encoder.encode import (
     compute_header, encode, encode_header, interp_positions)
 from quantized_mesh_encoder.normals import compute_vertex_normals
-from quantized_mesh_encoder.constants import WGS84
 
 
 def test_compute_header():
     positions = np.array([0, 0, 0, 1, 1, 1, 0, 1, 4], dtype=np.float32).reshape(
         -1, 3)
     cartesian_positions = to_ecef(positions)
-    header = compute_header(positions, cartesian_positions, sphere_method=None)
+    header = compute_header(positions, sphere_method=None)
     keys = [
         'centerX', 'centerY', 'centerZ', 'minimumHeight', 'maximumHeight',
         'boundingSphereCenterX', 'boundingSphereCenterY',
@@ -57,12 +57,14 @@ def test_encode_decode():
         [0, 0, 0, 1, 1, 1, 0, 1, 4, 2, 3, 4, 8, 9, 10, 12, 13, 14],
         dtype=np.float32)
     triangles = np.array([0, 1, 2, 1, 2, 3, 2, 3, 4, 3, 4, 5], dtype=np.uint32)
+
+    cartesian_positions = to_ecef(positions.reshape(-1, 3))
+
+    normals_ext = extensions.VertexNormalsExtension(
+        positions=positions, indices=triangles)
+
     f = BytesIO()
-    encode(
-        f,
-        positions,
-        triangles,
-        extensions=[extensions.VertexNormalsExtension()])
+    encode(f, positions, triangles, extensions=[normals_ext])
 
     f.seek(0)
     tile = TerrainTile()
@@ -84,8 +86,6 @@ def test_encode_decode():
     assert tile.eastI == [5]
     assert tile.northI == [5]
 
-    cartesian_positions = to_ecef(positions.reshape(-1, 3))
     normals = compute_vertex_normals(cartesian_positions, triangles)
-
     assert np.array_equal(
         normals, np.array(tile.vLight)), 'VertexNormals incorrect'


### PR DESCRIPTION
This PR adds support for encoding VertexNormals using the implementation added in #18 and with a refined public API to that initially presented in #32.

The results are looking good using these tiles to render an illuminated Lunar surface in Cesium 
![image](https://user-images.githubusercontent.com/381932/111712566-41daf180-8824-11eb-9c3f-460605b6603c.png)

What has me a bit stumped is getting a basic test of encode/decode of these vertexnormals working