### PR TITLE
Use scaledDirectionToPoint in occlusion computations

### DIFF
--- a/quantized_mesh_encoder/occlusion.py
+++ b/quantized_mesh_encoder/occlusion.py
@@ -41,11 +41,13 @@ def occlusion_point(
     # Scale positions relative to ellipsoid
     positions /= cartesian_ellipsoid
 
-    # Scale center relative to ellipsoid
-    bounding_center /= cartesian_ellipsoid
+    # Scale center relative to ellipsoid and normalize
+    # see https://github.com/CesiumGS/cesium/blob/9295450e64c3077d96ad579012068ea05f97842c/packages/engine/Source/Core/EllipsoidalOccluder.js#L398
+    scaledSpaceDirectionToPoint = bounding_center / cartesian_ellipsoid
+    scaledSpaceDirectionToPoint /= np.linalg.norm(scaledSpaceDirectionToPoint)
 
     # Find magnitudes necessary for each position to not be visible
-    magnitudes = compute_magnitude(positions, bounding_center)
+    magnitudes = compute_magnitude(positions, scaledSpaceDirectionToPoint)
 
     # Multiply by maximum magnitude and rescale to ellipsoid surface
-    return bounding_center * magnitudes.max() * cartesian_ellipsoid
+    return scaledSpaceDirectionToPoint * magnitudes.max() * cartesian_ellipsoid


### PR DESCRIPTION
WIP

I've been having issues with what seems like incorrectly culled tiles (especially at z0)  so I started taking a look at the `horizonOcclusionPoint` values. I have no true understanding of the math involved 😅 but in comparing the implementation here with https://github.com/CesiumGS/cesium/blob/9295450e64c3077d96ad579012068ea05f97842c/packages/engine/Source/Core/EllipsoidalOccluder.js#L398
I noticed this implementation wasn't making use of scaledDirectionToPoint like in the reference implementation. 

At least on my side, this change has resulted in fixing the tiles being incorrectly culled in Cesium. I should probably add tests, and validate some other things first. Putting this up early for feedback in case I'm missing something.